### PR TITLE
Remove deprecated version_compare

### DIFF
--- a/tasks/checks.yml
+++ b/tasks/checks.yml
@@ -7,7 +7,7 @@
 - name: Checking version of OS
   fail:
     msg: "{{ ansible_distribution_version}} of {{ ansible_distribution }} is not supported"
-  when: ansible_distribution_version|version_compare(os_minimum_versions[ansible_distribution], '<')
+  when: ansible_distribution_version is version(os_minimum_versions[ansible_distribution], '<')
 
 - name: Checking server_start_join is different of server_retry_join when consul is not enabled and server mode is selected
   fail:
@@ -37,4 +37,4 @@
 - name: Checking that disable_tagged_metrics is not true when nomad_version<0.7.0
   fail:
     msg: "disable_tagged_metrics must be true when nomad_version<0.7.0"
-  when: use_telemetry and not disable_tagged_metrics and nomad_version|version_compare(0.7.0, '<')
+  when: use_telemetry and not disable_tagged_metrics and nomad_version is version(0.7.0, '<')


### PR DESCRIPTION
version_compare is deprecated from ansible version 2.5 and it does not exist on 2.9